### PR TITLE
Add global provider alias for services like WAF that require us-east-1

### DIFF
--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -36,7 +36,7 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias = "global"
+  alias   = "global"
   profile = "${local.profile_name}"
   region  = "us-east-1"
 }

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -34,6 +34,12 @@ provider "aws" {
   profile = "${local.profile_name}"
   region  = "${local.region}"
 }
+
+provider "aws" {
+  alias = "global"
+  profile = "${local.profile_name}"
+  region  = "us-east-1"
+}
 EOF
 
 }


### PR DESCRIPTION
Per the [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#scope) for WAF scopes, any WAF that applies to a CloudFront distribution must explicitly specify the us-east-1 region. The easiest way for us to accomplish this, since we support deploying resources to regions based on their directory structure, is to use an alias to ensure that us-east-1 is available as a unique provider.

This will impact neither resources deployed to other regions, nor resources deployed to us-east-1 based on their folder path, it just allows us to easily reference us-east-1 when we need it in the following way:

```hcl

resource "aws_wafv2_web_acl" "waf_acl" {
  provider = aws.global
  
  scope = "CLOUDFRONT"
  name  = module.resource_names["waf_acl"].standard
  ...
}

```

In the above example, an alias of "global" on a provider of type "aws" yields an "aws.global" provider.