### PR TITLE
changing var from aws_profile to profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ envs:
         - <<region_1>>:
             instances:
               - "<<instance number>>"
-      aws_profile: <<aws profile used for authentication to connect to aws platform>>
+      profile: <<aws profile used for authentication to connect to aws platform>>
 ```
 
 `skeleton.yaml`(located at the root of the repository) is example file that generates terragrunt configurations for `dev`, `qa`, `uat`, `prod` environments, one instance each ("000") in `us-east-2` region. The terragrunt configuration is generated to deploy `s3 bucket` using wrapper module `tf-aws-wrapper_module-s3_bucket` and naming_prefix `demo-101`.

--- a/skeleton.yaml
+++ b/skeleton.yaml
@@ -7,22 +7,22 @@ envs:
         - us-east-2:
             instances:
               - "000"
-      aws_profile: aws-user-profile-dev
+      profile: aws-user-profile-dev
   - qa:
       regions:
         - us-east-2:
             instances:
               - "000"
-      aws_profile: aws-user-profile-qa
+      profile: aws-user-profile-qa
   - uat:
       regions:
         - us-east-2:
             instances:
               - "000"
-      aws_profile: aws-user-profile-uat
+      profile: aws-user-profile-uat
   - prod:
       regions:
         - us-east-2:
             instances:
               - "000"
-      aws_profile: aws-user-profile-prod
+      profile: aws-user-profile-prod

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -14,7 +14,7 @@ locals {
   region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
 
   account_name = local.account_vars.locals.account_name
-  region       = local.region_vars.locals.aws_region
+  region       = local.region_vars.locals.env_region
   accounts     = local.common_vars.locals.accounts
 
   # AWS Profile name


### PR DESCRIPTION
These changes are needed to the skeleton to make `caf-component-terragrunt` multi provider. 
- changing var `aws_profile` to `profile`
- changing var `aws_region` to `env_region`. 

This PR is dependent on: https://github.com/nexient-llc/caf-component-aws-terragrunt/pull/4/files